### PR TITLE
Prepare new DINI vocabulary for MIR

### DIFF
--- a/mycore.org/content/de/documentation/apps/mir/migration/migrate_mir2022_06.html
+++ b/mycore.org/content/de/documentation/apps/mir/migration/migrate_mir2022_06.html
@@ -18,13 +18,38 @@ draft: true
         Hier sind die Schritte zur MIR-Migration gelistet, die neben der <a href="{{< ref migrate_mcr2022_06 >}}">Migrationsanleitung für MyCoRe</a>
         noch relevant sind.
       </p>
-
-      <div>
-        <h3>...</h3>
-        <p>
-          ...
-        </p>
-      </div>
+        <div>
+          <h3>Neues DINI-Vokabular</h3>
+          <p>
+              Anfang des Jahres wurde eine neue Version des "Gemeinsames Vokabular für Publikations- und Dokumenttypen" der DINI
+              <a href="https://blogs.tib.eu/wp/dini-ag-blog/2022/03/21/gemeinsamen-vokabular/">vorgestellt</a>.
+              Dieses wird für das kommende DINI-Zertifikat 2022 eine Grundvoraussetzung.
+              Das neue Vokabular kann in MIR parallel zu dem alten Vokabular verwendet werden.
+              Dies ermöglicht den Umstieg auf die Anforderungen des neuen Zertifikats (z.B. OAI-Sets basierend auf dem neuen Vokabular) zu einem beliebigen Zeitpunkt.
+          </p>
+          <h4>Neues Vokabular anlegen</h4>
+          <p>
+            Zunächst muss das neue Vokabular angelegt werden. Hierzu kann das folgenden CLI-Kommando genutzt werden:
+            {{< highlight plain>}}load classification from url http://mycore.de/classifications/diniPublType2022.xml{{< /highlight >}}
+          </p>
+          <p>
+            Zudem muss die Klassifikation der Publikationsarten neu geladen werden:
+            {{< highlight plain>}}update classification from url http://mycore.de/classifications/mir_genres.xml{{< /highlight >}}
+            Die aktuelle Klassifikation der Publikationsarten beinhaltet Mappings für die alte und die neue Version des DINI-Vokabulars.
+          </p>
+          <p>
+            <em>Hinweis: Wer eine eigene Version der Klassifikation der Publikationsarten verwendet, muss die Mappings für die neue Version des DINI-Vokabulars auf geeignete Weise selbst hinzufügen.</em>
+          </p>
+          <h4>Neues Vokabular verwenden</h4>
+          <p>
+            Anschließend müssen die Event-Handler für alle Objekte erneut durchlaufen. Hierzu kann das folgenden CLI-Kommando genutzt werden:
+            {{< highlight plain>}}repair metadata search of type mods{{< /highlight >}}
+            Hierdurch werden in allen Objekten Einträge der Form
+            <code>&lt;mods:classification generator="mir_genres2diniPublType2022-mycore" ... /&gt;</code>
+            ergänzt und die Index Index-Felder <code>category</code> und <code>category.top</code>
+            um die passenden Werte der Form <code>diniPublType2022:...</code> erweitert.
+          </p>
+       </div>
     </div>
 
 

--- a/mycore.org/static/classifications/index.html
+++ b/mycore.org/static/classifications/index.html
@@ -28,6 +28,9 @@
         <a class="http" href="diniPublType.xml">http://www.mycore.de/classifications/diniPublType.xml</a>
       </li>
       <li>
+        <a class="http" href="diniPublType2022.xml">http://www.mycore.de/classifications/diniPublType2022.xml</a>
+      </li>
+      <li>
         <a class="http" href="diniVersion.xml">http://www.mycore.de/classifications/diniVersion.xml</a>
       </li>
       <li>

--- a/mycore.org/static/classifications/mir_genres.xml
+++ b/mycore.org/static/classifications/mir_genres.xml
@@ -6,14 +6,14 @@
   <categories>
     <category ID="article">
       <label xml:lang="it" text="Articolo / Saggio" />
-      <label xml:lang="x-mapping" text="marcgt:article diniPublType:article" />
+      <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:Article" />
       <label xml:lang="en" text="Article / Chapter" />
       <label xml:lang="de" text="Artikel / Aufsatz" />
       <label xml:lang="x-hosts" text="journal newspaper collection festschrift proceedings standalone" />
       <category ID="chapter">
         <label xml:lang="en" text="Book chapter" />
         <label xml:lang="de" text="Buchkapitel" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart" />
         <label xml:lang="x-hosts" text="book collection" />
         <label xml:lang="it" text="Capitolo di libro" />
       </category>
@@ -22,31 +22,31 @@
         <label xml:lang="x-hosts" text="lexicon" />
         <label xml:lang="it" text="Entrata Lessicale" />
         <label xml:lang="de" text="Lexikoneintrag" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart" />
       </category>
       <category ID="preface">
         <label xml:lang="de" text="Vorwort / Nachwort" />
         <label xml:lang="x-hosts" text="journal collection festschrift proceedings lexicon" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart" />
         <label xml:lang="it" text="Prefazione / Epilogo" />
         <label xml:lang="en" text="Preface (foreword) / Postface" />
       </category>
       <category ID="speech">
         <label xml:lang="en" text="Lecture / Speech" />
         <label xml:lang="it" text="Conferenza" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:other" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:other diniPublType2022:Other" />
         <label xml:lang="de" text="Vortrag" />
         <label xml:lang="x-hosts" text="proceedings standalone" />
       </category>
       <category ID="review">
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:review" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:review diniPublType2022:Recension" />
         <label xml:lang="it" text="Recensione" />
         <label xml:lang="de" text="Rezension" />
         <label xml:lang="en" text="Review" />
         <label xml:lang="x-hosts" text="journal newspaper collection festschrift proceedings standalone" />
       </category>
       <category ID="blog_entry">
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:article" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:PartOfADynamicWebRessource" />
         <label xml:lang="x-hosts" text="blog" />
         <label xml:lang="en" text="Blog entry" />
         <label xml:lang="de" text="Blog-Eintrag" />
@@ -61,7 +61,7 @@
       <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:workingPaper XMetaDissPlusThesisLevel:other" />
       <label xml:lang="it" text="Tesi universitaria" />
       <category ID="exam">
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis XMetaDissPlusThesisLevel:Staatsexamen" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis XMetaDissPlusThesisLevel:Staatsexamen" />
         <label xml:lang="en" text="Exam" />
         <label xml:lang="it" text="Esame" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -70,22 +70,22 @@
       <category ID="dissertation">
         <label xml:lang="it" text="Tesi di Dottorato di ricerca" />
         <label xml:lang="de" text="Dissertation" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis XMetaDissPlusThesisLevel:thesis.doctoral" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:PhDThesis XMetaDissPlusThesisLevel:thesis.doctoral" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="en" text="Dissertation" />
       </category>
       <category ID="habilitation">
         <label xml:lang="de" text="Habilitation" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis XMetaDissPlusThesisLevel:thesis.habilitation" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:Habilitation XMetaDissPlusThesisLevel:thesis.habilitation" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Tesi di abilitazione alla libera docenza" />
         <label xml:lang="en" text="Habilitation" />
       </category>
       <category ID="diploma_thesis">
         <label xml:lang="it" text="Tesi di diploma" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis XMetaDissPlusThesisLevel:Diplom" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis XMetaDissPlusThesisLevel:Diplom" />
         <label xml:lang="en" text="Diploma thesis" />
-        <label xml:lang="x-hosts" text="series standalone diniPublType:masterThesis" />
+        <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Diplomarbeit" />
       </category>
       <category ID="master_thesis">
@@ -93,11 +93,11 @@
         <label xml:lang="en" text="Master thesis" />
         <label xml:lang="de" text="Abschlussarbeit (Master)" />
         <label xml:lang="x-hosts" text="series standalone" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis XMetaDissPlusThesisLevel:master" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis XMetaDissPlusThesisLevel:master" />
       </category>
       <category ID="bachelor_thesis">
         <label xml:lang="it" text="Tesi di laurea triennale" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:bachelorThesis XMetaDissPlusThesisLevel:bachelor" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:bachelorThesis diniPublType2022:BachelorThesis XMetaDissPlusThesisLevel:bachelor" />
         <label xml:lang="de" text="Abschlussarbeit (Bachelor)" />
         <label xml:lang="en" text="Bachelor thesis" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -105,13 +105,13 @@
       <category ID="student_resarch_project">
         <label xml:lang="it" text="Tesina" />
         <label xml:lang="en" text="Student research project" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:StudyThesis XMetaDissPlusThesisLevel:other" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:StudyThesis diniPublType2022:StudyThesis XMetaDissPlusThesisLevel:other" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Studienarbeit" />
       </category>
       <category ID="magister_thesis">
         <label xml:lang="en" text="Magister thesis" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis XMetaDissPlusThesisLevel:M.A." />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis XMetaDissPlusThesisLevel:M.A." />
         <label xml:lang="de" text="Magisterarbeit" />
         <label xml:lang="it" text="Magisterarbeit" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -119,26 +119,26 @@
     </category>
     <category ID="collection">
       <label xml:lang="de" text="Sammelwerk" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:EditedCollection" />
       <label xml:lang="it" text="Compilazione" />
       <label xml:lang="x-hosts" text="series standalone" />
       <label xml:lang="en" text="Collection" />
       <category ID="festschrift">
         <label xml:lang="en" text="Festschrift" />
-        <label xml:lang="x-mapping" text="marcgt:festschrift diniPublType:report" />
+        <label xml:lang="x-mapping" text="marcgt:festschrift diniPublType:report diniPublType2022:Report" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Festschrift" />
         <label xml:lang="it" text="Commemorativo" />
       </category>
       <category ID="proceedings">
-        <label xml:lang="x-mapping" text="marcgt:conference_publication diniPublType:conferenceObject" />
+        <label xml:lang="x-mapping" text="marcgt:conference_publication diniPublType:conferenceObject diniPublType2022:ConferenceProceedings" />
         <label xml:lang="en" text="Proceedings" />
         <label xml:lang="de" text="Tagungsband" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Procedimento" />
       </category>
       <category ID="lexicon">
-        <label xml:lang="x-mapping" text="marcgt:encyclopedia diniPublType:book" />
+        <label xml:lang="x-mapping" text="marcgt:encyclopedia diniPublType:book diniPublType2022:Book" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Lessico" />
         <label xml:lang="de" text="Lexikon" />
@@ -148,19 +148,19 @@
     <category ID="report">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Report" />
-      <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report" />
+      <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report" />
       <label xml:lang="en" text="Report" />
       <label xml:lang="it" text="Rapporto" />
       <category ID="research_results">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report" />
         <label xml:lang="en" text="Research Results" />
         <label xml:lang="de" text="Forschungsergebnisse" />
         <label xml:lang="it" text="Risultati della ricerca" />
       </category>
       <category ID="in_house">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report" />
         <label xml:lang="en" text="In house" />
         <label xml:lang="it" text="In-house pubblicazione" />
         <label xml:lang="de" text="Hausinterne Veröffentlichung" />
@@ -168,13 +168,13 @@
       <category ID="press_release">
         <label xml:lang="x-hosts" text="standalone" />
         <label xml:lang="it" text="Comunicato stampa" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report" />
         <label xml:lang="de" text="Presseerklärung" />
         <label xml:lang="en" text="Press release" />
       </category>
       <category ID="declaration">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report" />
         <label xml:lang="de" text="Fachliche Stellungnahme" />
         <label xml:lang="en" text="Professional declaration" />
         <label xml:lang="it" text="Parere di esperti" />
@@ -183,18 +183,18 @@
     <category ID="teaching_material">
       <label xml:lang="de" text="Lehrmaterial" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial" />
+      <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial" />
       <label xml:lang="en" text="Teaching Resource" />
       <label xml:lang="it" text="Materiale didattico" />
       <category ID="lecture_resource">
         <label xml:lang="x-hosts" text="standalone lecture" />
-        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial" />
+        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial" />
         <label xml:lang="de" text="Vorlesungsmaterial" />
         <label xml:lang="en" text="Lecture Resource" />
         <label xml:lang="it" text="Resource Lecture" />
       </category>
       <category ID="course_resources">
-        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial" />
+        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial" />
         <label xml:lang="x-hosts" text="standalone lecture" />
         <label xml:lang="de" text="Kurs- und Seminarmaterial" />
         <label xml:lang="en" text="Course Resources" />
@@ -204,7 +204,7 @@
     <category ID="book">
       <label xml:lang="it" text="Libro" />
       <label xml:lang="de" text="Buch" />
-      <label xml:lang="x-mapping" text="marcgt:book diniPublType:book" />
+      <label xml:lang="x-mapping" text="marcgt:book diniPublType:book diniPublType2022:Book" />
       <label xml:lang="x-hosts" text="series standalone" />
       <label xml:lang="en" text="Book" />
     </category>
@@ -213,18 +213,18 @@
       <label xml:lang="en" text="Journal" />
       <label xml:lang="de" text="Zeitschrift" />
       <label xml:lang="it" text="Rivista" />
-      <label xml:lang="x-mapping" text="marcgt:journal diniPublType:Periodical" />
+      <label xml:lang="x-mapping" text="marcgt:journal diniPublType:Periodical diniPublType2022:Periodical" />
     </category>
     <category ID="newspaper">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="it" text="Giornale" />
       <label xml:lang="en" text="Newspaper" />
-      <label xml:lang="x-mapping" text="marcgt:newspaper diniPublType:Periodical" />
+      <label xml:lang="x-mapping" text="marcgt:newspaper diniPublType:Periodical diniPublType2022:Periodical" />
       <label xml:lang="de" text="Zeitung" />
     </category>
     <category ID="series">
       <label xml:lang="x-hosts" text="standalone" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:Other" />
       <label xml:lang="en" text="Series" />
       <label xml:lang="de" text="Serie" />
       <label xml:lang="it" text="Collana" />
@@ -232,14 +232,14 @@
     <category ID="blog">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Blog" />
-      <label xml:lang="x-mapping" text="marcgt:web_site diniPublType:Website" />
+      <label xml:lang="x-mapping" text="marcgt:web_site diniPublType:Website diniPublType2022:DynamicWebRessource" />
       <label xml:lang="en" text="Blog" />
       <label xml:lang="it" text="Blog" />
     </category>
     <category ID="interview">
       <label xml:lang="it" text="Intervista" />
       <label xml:lang="x-hosts" text="journal newspaper standalone" />
-      <label xml:lang="x-mapping" text="marcgt:interview diniPublType:report" />
+      <label xml:lang="x-mapping" text="marcgt:interview diniPublType:report diniPublType2022:Report" />
       <label xml:lang="en" text="Interview" />
       <label xml:lang="de" text="Interview" />
     </category>
@@ -247,11 +247,11 @@
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Forschungsdaten" />
       <label xml:lang="en" text="Research Data" />
-      <label xml:lang="x-mapping" text="marcgt:database diniPublType:ResearchData" />
+      <label xml:lang="x-mapping" text="marcgt:database diniPublType:ResearchData diniPublType2022:ResearchData" />
       <label xml:lang="it" text="Dati di ricerca" />
       <category ID="software">
         <label xml:lang="en" text="Software" />
-        <label xml:lang="x-mapping" text="marcgt:computer_program diniPublType:Software" />
+        <label xml:lang="x-mapping" text="marcgt:computer_program diniPublType:Software diniPublType2022:Software" />
         <label xml:lang="x-hosts" text="standalone" />
         <label xml:lang="de" text="Software" />
       </category>
@@ -259,12 +259,12 @@
     <category ID="patent">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="it" text="Brevetto" />
-      <label xml:lang="x-mapping" text="marcgt:patent diniPublType:patent" />
+      <label xml:lang="x-mapping" text="marcgt:patent diniPublType:patent diniPublType2022:Patent" />
       <label xml:lang="de" text="Patent" />
       <label xml:lang="en" text="Patent" />
     </category>
     <category ID="poster">
-      <label xml:lang="x-mapping" text="marcgt:technical_drawing diniPublType:ResearchData" />
+      <label xml:lang="x-mapping" text="marcgt:technical_drawing diniPublType:ResearchData diniPublType2022:ConferencePoster" />
       <label xml:lang="en" text="Poster" />
       <label xml:lang="it" text="Locandina" />
       <label xml:lang="de" text="Poster" />
@@ -273,7 +273,7 @@
     <category ID="audio">
       <label xml:lang="en" text="Audio file" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:sound diniPublType:Sound" />
+      <label xml:lang="x-mapping" text="marcgt:sound diniPublType:Sound diniPublType2022:Sound" />
       <label xml:lang="de" text="Tondokument" />
       <label xml:lang="it" text="Registrazione audio" />
     </category>
@@ -282,18 +282,18 @@
       <label xml:lang="it" text="Film / Video" />
       <label xml:lang="de" text="Film / Video" />
       <label xml:lang="en" text="Movie / Video" />
-      <label xml:lang="x-mapping" text="marcgt:motion_picture diniPublType:MovingImage" />
+      <label xml:lang="x-mapping" text="marcgt:motion_picture diniPublType:MovingImage diniPublType2022:MovingImage" />
     </category>
     <category ID="picture">
       <label xml:lang="it" text="Immagine" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:picture diniPublType:StillImage" />
+      <label xml:lang="x-mapping" text="marcgt:picture diniPublType:StillImage diniPublType2022:StillImage" />
       <label xml:lang="de" text="Bild" />
       <label xml:lang="en" text="Picture" />
     </category>
     <category ID="broadcasting">
       <label xml:lang="x-hosts" text="standalone" />
-      <label xml:lang="x-mapping" text="marcgt:videorecording diniPublType:report" />
+      <label xml:lang="x-mapping" text="marcgt:videorecording diniPublType:report diniPublType2022:Report" />
       <label xml:lang="it" text="Programma televisivo o radiofonico" />
       <label xml:lang="de" text="Sendung" />
       <label xml:lang="en" text="Broadcasting" />
@@ -302,7 +302,7 @@
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Vorlesung" />
       <label xml:lang="en" text="Lecture" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:lecture" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:lecture diniPublType2022:Lecture" />
       <label xml:lang="it" text="Lezione" />
     </category>
   </categories>


### PR DESCRIPTION
This PR will add mappings for the new version of the DINI vocabulary to the MIR genres and add a description for the necessary migrations steps that should be performed when upgrading to the new Version of MIR in order to be prepared, in this regard, for the upcoming version of the DINI certificate.