### PR TITLE
Fix mvn compile using an old antrun plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
           <execution>
             <phase>generate-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <copy todir="${basedir}/mycore.org/themes/mycore-bootstrap/static/_gen/webjars">
                   <fileset dir="${project.build.directory}/_webjars/META-INF/resources/webjars">
                     <include name="**/jquery.min.js" />
@@ -144,7 +144,7 @@
                     <include name="**/bootstrap/*/scss/**" />
                   </fileset>
                 </copy>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Build fails using maven-antrun-plugin: 3.1.0. Error message: You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site.