### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-classifications</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
mycore-classifications version 1.1-SNAPSHOT is not available in the sonatype snapshot repo. Updated version of dependency.