### PR TITLE
Fix Solr Java API description in 2026.06 migration guide

### DIFF
--- a/mycore.org/content/de/documentation/migrate/migrate_mcr2026_06.md
+++ b/mycore.org/content/de/documentation/migrate/migrate_mcr2026_06.md
@@ -65,7 +65,7 @@ bleiben aber zunächst noch funktionsfähig.
 - Die Konfiguration der Solr-Kerne erfolgt nun über `MCR.Solr.IndexRegistry.Index.{id}.*` statt `MCR.Solr.Core.{id}.*`.
 - Der Verbindungstyp (Standalone / SolrCloud) wird über eine `Class`-Property explizit festgelegt.
 - Client-Timeouts und Parallelisierungs-Properties wurden unter `MCR.Solr.Default.*` zusammengefasst.
-- Die Java-Klassen `MCRSolrClientFactory` und `MCRSolrCoreManager` sind deprecated und werden mit dem nächsten Release entfernt.
+- Die Java-Klassen `MCRSolrCore` und `MCRSolrCoreManager` wurden entfernt; der Zugriff auf Solr-Clients erfolgt nun über die Index-Registry.
 
 ## Migrationsschritte
 
@@ -232,14 +232,14 @@ Den Konfigurationsassistenten zum Erzeugen der Properties für alle Verbindungst
 man in der [Solr-Dokumentation]({{< ref search_solr_use >}}).
     </p>
 
-#### Java API: `MCRSolrClientFactory` und `MCRSolrCoreManager`
+#### Java API: `MCRSolrCoreManager`
 
-Die Klassen `MCRSolrClientFactory` und `MCRSolrCoreManager` sind
-deprecated. Der Zugriff auf Solr-Clients erfolgt nun über die Index-Registry:
+Die Klassen `MCRSolrCore` und `MCRSolrCoreManager` wurden
+entfernt. Der Zugriff auf Solr-Clients erfolgt nun über die Index-Registry:
 
 ```java
 // ALT (bis 2025.12)
-SolrClient client = MCRSolrClientFactory.getMainSolrClient();
+SolrClient client = MCRSolrCoreManager.getMainSolrClient();
 // oder:
 SolrClient client = MCRSolrCoreManager.get("main").get().getClient();
 


### PR DESCRIPTION
## Hintergrund

Rückmeldung per Mail zur Migrations-Anleitung **2025.12 → 2026.06**, Abschnitt zur Solr-Integration (MCR-3645).

## Korrekturen

- **`MCRSolrClientFactory` entfernt:** Die Klasse wurde bereits mit **2024.06** in `MCRSolrCoreManager` umbenannt (git rename). Sie ist also nicht Teil der 2025.12-Ausgangsbasis und gehört nicht in eine 2025.12→2026.06-Anleitung. Das `ALT`-Beispiel nutzt jetzt das real in 2025.12 vorhandene `MCRSolrCoreManager.getMainSolrClient()`.
- **"deprecated" → "entfernt":** `MCRSolrCore` und `MCRSolrCoreManager` sind in 2026.06 vollständig entfernt (0 Vorkommen im Quellcode von `origin/2026.06.x`), nicht nur deprecated.

## Verifikation

Gegen ausgechecktes `origin/2026.06.x` geprüft:
- Alte Klassen (`MCRSolrCore`, `MCRSolrCoreManager`): nicht mehr vorhanden.
- Neue Index-Registry-API des `NEU`-Beispiels existiert und kompiliert: `MCRSolrIndexRegistryManager.obtainRegistry()` → `MCRSolrIndexRegistry.getIndex(String)` → `Optional<MCRSolrIndex>` → `MCRSolrIndex.getClient()` → `SolrClient`.