### PR TITLE
DOC-68 Migrationshinweis: Verschiebung jats2mods.xsl nach xslt/

### DIFF
--- a/mycore.org/content/de/documentation/apps/mir/migration/migrate_mir2023_06.html
+++ b/mycore.org/content/de/documentation/apps/mir/migration/migrate_mir2023_06.html
@@ -73,6 +73,32 @@ date: "2023-07-11"
       Dieses Problem wurde nachträglich entdeckt und betrifft auch die Versionen 2024 und 2025.
     </p>
   </div>
+  <!-- https://mycore.atlassian.net/browse/MCR-2966 -->
+  <h3>Verschiebung der "Saxon ready"-Stylesheets nach <code>xslt/</code></h3>
+  <p>
+    Mit <a href="https://mycore.atlassian.net/browse/MCR-2966">MCR-2966</a> wurden die XSLT3-fähigen
+    ("Saxon ready") Stylesheets aus dem Verzeichnis <code>xsl/</code> nach <code>xslt/</code> verschoben.
+    Für die meisten Stylesheets ist das unkritisch, da die zugehörigen Properties in der
+    MIR-<code>mycore.properties</code> mitgepflegt wurden und beim Update automatisch übernommen werden.
+  </p>
+  <p>
+    Problematisch ist das Stylesheet für den DeepGreen-JATS-Import
+    (<code>sword/jats2mods.xsl</code>). Die zugehörige Property ist in der
+    MIR-<code>mycore.properties</code> nur <strong>auskommentiert</strong> enthalten:
+    {{< highlight plain>}}
+    # MCR.ContentTransformer.deepgreenjats2mods.Stylesheet=xslt/sword/jats2mods.xsl
+    {{< /highlight >}}
+    Anwendungen, die diese Property in einer älteren Version in ihre eigene <code>mycore.properties</code>
+    kopiert und aktiviert haben, verweisen weiterhin auf den alten Pfad <code>xsl/sword/jats2mods.xsl</code>
+    und werden durch das Update <strong>nicht</strong> automatisch angepasst.
+  </p>
+  <p>
+    Betroffene Anwendungen (mit aktiviertem DeepGreen-/SWORD-Import) müssen den Pfad in ihrer eigenen
+    <code>mycore.properties</code> daher manuell anpassen:
+    {{< highlight plain>}}
+    MCR.ContentTransformer.deepgreenjats2mods.Stylesheet=xslt/sword/jats2mods.xsl
+    {{< /highlight >}}
+  </p>
 </div>
 
 


### PR DESCRIPTION
[Link zu Jira](https://mycore.atlassian.net/browse/DOC-68)

## Problem

Der Commit [be7dd35](https://github.com/MyCoRe-Org/mir/commit/be7dd35a90dd59cb9583f5134ee5da03a2ef6c0c) ("MCR-2966 move Saxon ready stylesheets to /xslt", Release MIR LTS 2023.06 / Tag `v2023.06.0`) hat die XSLT3-fähigen Stylesheets von `xsl/` nach `xslt/` verschoben.

Für die meisten Stylesheets unkritisch, da die Pfade in der MIR-`mycore.properties` mitgepflegt werden. Beim DeepGreen-JATS-Stylesheet (`sword/jats2mods.xsl`) steht die zugehörige Property `MCR.ContentTransformer.deepgreenjats2mods.Stylesheet` jedoch nur **auskommentiert** drin. Anwendungen, die diese Stelle in einer älteren Version in ihre eigene `mycore.properties` kopiert und aktiviert haben, verweisen weiter auf `xsl/sword/jats2mods.xsl` und werden durch das Update nicht automatisch angepasst → der DeepGreen-/SWORD-Import bricht.

## Änderung

Migrationsanweisung `migrate_mir2023_06.html` (Migration 2022.06 → 2023.06) um einen Abschnitt ergänzt, der die Verschiebung erklärt und die nötige manuelle Anpassung (`xslt/sword/jats2mods.xsl`) zeigt.

## Referenzen

- Verschiebung: [MCR-2966](https://mycore.atlassian.net/browse/MCR-2966)
- XSLT3-Update jats2mods.xsl: [MIR-1213](https://mycore.atlassian.net/browse/MIR-1213)

[MCR-2966]: https://mycore.atlassian.net/browse/MCR-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ