### PR TITLE
DOC-69 text/html-Content via Hugo security.allowContent erlauben

### DIFF
--- a/mycore.org/config/_default/config.yaml
+++ b/mycore.org/config/_default/config.yaml
@@ -65,4 +65,11 @@ markup:
     renderer:
       unsafe: true
   highlight:
-    guessSyntax: true 
+    guessSyntax: true
+
+# Diese Website besteht aus HTML-Content-Dateien. Seit Hugo v0.158 blockt die
+# Security-Policy "security.allowContent" den Medientyp text/html standardmäßig.
+# Daher wird text/html hier wieder explizit erlaubt.
+security:
+  allowContent:
+    - '.*'

--- a/mycore.org/config/_default/config.yaml
+++ b/mycore.org/config/_default/config.yaml
@@ -67,8 +67,9 @@ markup:
   highlight:
     guessSyntax: true
 
-# Diese Website besteht aus HTML-Content-Dateien. Seit Hugo v0.158 blockt die
-# Security-Policy "security.allowContent" den Medientyp text/html standardmäßig.
+# Diese Website basiert vorrangig auf HTML-Content-Dateien.
+# Seit Hugo v0.158 blockt die Security-Policy "security.allowContent" den Medientyp
+# text/html standardmäßig (siehe https://gohugo.io/configuration/security/).
 # Daher wird text/html hier wieder explizit erlaubt.
 security:
   allowContent:


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/DOC-69)

Seit Hugo v0.158 (getestet mit v0.163.3) blockt die Security-Policy `security.allowContent` den Medientyp `text/html` standardmäßig. Da die mycore-website nahezu vollständig aus `.html`-Content-Dateien besteht, schlägt der Build (`hugo` / `hugo serve`) fehl:

```
ERROR error building site: assemble: failed to create page from pageMetaSource ...:
access denied: "text/html" is not whitelisted in policy "security.allowContent";
```

Fix in `mycore.org/config/_default/config.yaml`:

```yaml
security:
  allowContent:
    - '.*'
```

Danach baut die Seite wieder fehlerfrei (alle Sprachen, getestet mit Hugo v0.163.3).

Die verbleibenden Deprecation-Warnungen (`languages.*.languageName` → `label`, `.Language.LanguageCode` → `Locale`, `.Site.BuildDrafts`) sind nicht Teil dieses PRs.